### PR TITLE
Improve screenshot handling and server auth

### DIFF
--- a/__tests__/game-manager.test.js
+++ b/__tests__/game-manager.test.js
@@ -28,4 +28,22 @@ describe('GameManager screenshot', () => {
     expect(data).toEqual(new Uint8Array([1,2,3]));
     jest.useRealTimers();
   });
+
+  test('rejects if screenshot file not created', async () => {
+    jest.useFakeTimers();
+    const FS = {
+      unlink: jest.fn(),
+      stat: jest.fn(() => { throw new Error('ENOENT'); }),
+      readFile: jest.fn()
+    };
+    const gm = Object.create(global.window.EJS_GameManager.prototype);
+    gm.FS = FS;
+    gm.functions = { screenshot: jest.fn() };
+
+    const promise = gm.screenshot(100, 10);
+    jest.advanceTimersByTime(150);
+
+    await expect(promise).rejects.toThrow('screenshot timeout');
+    jest.useRealTimers();
+  });
 });


### PR DESCRIPTION
## Summary
- Add timeout and documentation to screenshot method, avoiding hangs
- Provide optional debug logging and allow admin requests when no admin key is configured
- Test screenshot timeout behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68915e87504c8331813f161a751a8d36