### PR TITLE
fix: improve server startup and logging

### DIFF
--- a/__tests__/netplay-server.test.js
+++ b/__tests__/netplay-server.test.js
@@ -1,8 +1,19 @@
-import { createRoom, joinRoom, updateState, rooms } from '../server/netplay-server.js';
+import { createRoom, joinRoom, updateState, rooms, startServer } from '../server/netplay-server.js';
 
 describe('netplay-server room lifecycle', () => {
+  let server;
   afterEach(() => {
     rooms.clear();
+    if (server && server.listening) {
+      server.close();
+      server = null;
+    }
+  });
+
+  test('startServer starts listening', async () => {
+    server = startServer();
+    await new Promise(res => server.on('listening', res));
+    expect(server.listening).toBe(true);
   });
 
   test('creates a room with given id', () => {

--- a/server/netplay-server.js
+++ b/server/netplay-server.js
@@ -122,7 +122,9 @@ function readBody(req) {
     req.on('end', () => {
       try {
         resolve(data ? JSON.parse(data) : {});
-      } catch {
+      } catch (err) {
+        // Log parse failures to aid debugging of malformed requests
+        console.error('Failed to parse request body:', err);
         resolve({});
       }
     });
@@ -413,6 +415,8 @@ function startServer() {
   httpServer.listen(PORT, () => {
     console.log(`Netplay server listening on ${PORT}`);
   });
+  return httpServer;
 }
 
-export { createRoom, joinRoom, updateState, rooms };
+// Export server utilities for external usage and testing.
+export { createRoom, joinRoom, updateState, rooms, startServer };

--- a/start.js
+++ b/start.js
@@ -1,11 +1,19 @@
 import { spawn } from 'child_process';
 import { resolve } from 'path';
 
+// Launch a child process and forward stdio so output is visible. Log
+// start/end events and surface spawn errors for easier debugging.
 function run(cmd, args) {
+  console.log(`Starting ${cmd} ${args.join(' ')}`.trim());
   const child = spawn(cmd, args, { stdio: 'inherit' });
+  child.on('error', err => {
+    console.error(`Failed to start ${cmd}:`, err);
+  });
   child.on('close', code => {
     if (code && code !== 0) {
       console.error(`${cmd} exited with code ${code}`);
+    } else {
+      console.log(`${cmd} exited`);
     }
   });
   return child;
@@ -15,7 +23,9 @@ const procs = [];
 procs.push(run('http-server', []));
 procs.push(run('node', [resolve('server', 'netplay-server.js')]));
 
+// Terminate all spawned processes on shutdown signals.
 function shutDown(signal) {
+  console.log(`Received ${signal}, shutting down...`);
   for (const p of procs) {
     p.kill(signal);
   }


### PR DESCRIPTION
## Summary
- add detailed logging and shutdown handling for start script
- log malformed request bodies and export startServer
- test server start functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68915e87504c8331813f161a751a8d36