### PR TITLE
feat: enforce CORS allow-list and improve server logging

### DIFF
--- a/__tests__/netplay-cors.test.js
+++ b/__tests__/netplay-cors.test.js
@@ -1,0 +1,23 @@
+import http from 'http';
+import { jest } from '@jest/globals';
+
+describe('netplay-server CORS handling', () => {
+  test('rejects requests from disallowed origins', async () => {
+    process.env.ALLOWED_DOMAINS = 'https://allowed.com';
+    jest.resetModules();
+    const { httpServer } = await import('../server/netplay-server.js');
+    await new Promise(resolve => httpServer.listen(0, resolve));
+    const port = httpServer.address().port;
+    const result = await new Promise(resolve => {
+      const req = http.request({ port, path: '/rooms', headers: { origin: 'https://blocked.com' } }, res => {
+        let data = '';
+        res.on('data', d => (data += d));
+        res.on('end', () => resolve({ statusCode: res.statusCode, body: data }));
+      });
+      req.end();
+    });
+    expect(result.statusCode).toBe(403);
+    httpServer.close();
+    delete process.env.ALLOWED_DOMAINS;
+  });
+});

--- a/server/netplay-server.js
+++ b/server/netplay-server.js
@@ -116,13 +116,18 @@ function checkAuth(req, query, admin = false) {
 }
 
 function readBody(req) {
+  // Reads and parses JSON request bodies. If parsing fails,
+  // the error is logged and an empty object is returned instead
+  // of throwing to the caller.
   return new Promise(resolve => {
     let data = '';
     req.on('data', chunk => (data += chunk));
     req.on('end', () => {
+      if (!data) return resolve({});
       try {
-        resolve(data ? JSON.parse(data) : {});
-      } catch {
+        resolve(JSON.parse(data));
+      } catch (err) {
+        console.warn('Failed to parse request body:', err);
         resolve({});
       }
     });
@@ -131,7 +136,16 @@ function readBody(req) {
 
 const httpServer = createServer(async (req, res) => {
   const { pathname, query } = parse(req.url, true);
-  res.setHeader('Access-Control-Allow-Origin', '*');
+  // Restrict CORS headers based on configured allowed domains
+  const origin = req.headers.origin;
+  if (ALLOWED_DOMAINS.includes('*') || !origin || ALLOWED_DOMAINS.includes(origin)) {
+    res.setHeader('Access-Control-Allow-Origin', origin || '*');
+  } else {
+    res.statusCode = 403;
+    res.end(JSON.stringify({ error: 'forbidden' }));
+    console.warn(`Blocked request from origin: ${origin}`);
+    return;
+  }
   res.setHeader('Content-Type', 'application/json');
 
   if (req.method === 'POST' && pathname === '/token') {
@@ -415,4 +429,4 @@ function startServer() {
   });
 }
 
-export { createRoom, joinRoom, updateState, rooms };
+export { createRoom, joinRoom, updateState, rooms, httpServer };


### PR DESCRIPTION
## Summary
- add request body parse logging
- respect ALLOWED_DOMAINS for HTTP CORS and log blocked origins
- export server for testing and cover CORS rejection with a new test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68915e87504c8331813f161a751a8d36